### PR TITLE
package.json: link to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.3.0",
   "description": "Auto reloading PureScript compiler",
   "main": "psc-pane.js",
+  "repository": "https://github.com/anttih/psc-pane",
   "bin": {
     "psc-pane": "index.js"
   },


### PR DESCRIPTION
I found out about this via a link to https://www.npmjs.com/package/psc-pane and without this link, there's no backlink to the GitHub page. :)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/anttih/psc-pane/4)

<!-- Reviewable:end -->
